### PR TITLE
show a courtesy loading message instead of an undefined

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -238,12 +238,12 @@ const Home = (props) => {
                 <>
                   <FeatureCard
                     key={1}
-                    title={wouldyoustats.servers + "+" + " " + "Global Servers"}
+                    title={wouldyoustats.servers ? wouldyoustats.servers + "+" + " " + "Global Servers" : "Loading..."}
                     image_src="/assets/server.svg"
                   ></FeatureCard>
                   <FeatureCard
                     key={2}
-                    title={wouldyoustats.users + "+" + " " + "Active Users"}
+                    title={wouldyoustats.users ? wouldyoustats.users + "+" + " " + "Active Users" : "Loading..."}
                     image_src="/assets/user.svg"
                   ></FeatureCard>
                   <FeatureCard


### PR DESCRIPTION
Hi! 
Just saw the issue about the "undefined" string in the stats; sorry if I didn't reply to the issue, however here is a quick fix that shows a courtesy "loading" message to the user instead of the "undefined" in the stats section.

Feel free to merge this! :)
